### PR TITLE
remove "+" sign after comma

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -140,7 +140,7 @@ else:
 		file.write(jvmARGs[1])
 
 print()
-print("Now, all you have to do is copy the files from another modpack's .minecraft (or minecraft) folder.\n",+"The forge_early.cfg file shouldn't be replaced, as it contains an important input fix.")
+print("Now, all you have to do is copy the files from another modpack's .minecraft (or minecraft) folder.\n", "The forge_early.cfg file shouldn't be replaced, as it contains an important input fix.")
 print()
 
 


### PR DESCRIPTION
Fixes: Traceback (most recent call last):
  File "/root/CleanroomInstallerScript/installer.py", line 143, in <module>

seen on Python 3.9.18 in Rocky Linux release 9.4 (Blue Onyx)